### PR TITLE
Added ffmpeg for redmatic-homekit-camera support

### DIFF
--- a/.docker/Dockerfile.alpine
+++ b/.docker/Dockerfile.alpine
@@ -37,6 +37,7 @@ RUN set -ex \
       avahi-compat-libdns_sd \
       avahi-dev \
       dbus \
+      ffmpeg \
     && npm set package-lock=false
 
 # s6 overlay


### PR DESCRIPTION
The node redmatic-homekit-camera requires ffmpeg to be available to provide pictures/video to the HomeKit App.